### PR TITLE
Automatic update of Microsoft.AspNetCore.Authentication.JwtBearer to 5.0.16

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.16" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.JwtBearer` to `5.0.16` from `5.0.6`
`Microsoft.AspNetCore.Authentication.JwtBearer 5.0.16` was published at `2022-04-11T23:48:53Z`, 1 day ago
There is also a higher version, `Microsoft.AspNetCore.Authentication.JwtBearer 6.0.4` published at `2022-04-11T23:52:28Z`, 1 day ago, but this was not applied as only `Patch` version changes are allowed.

1 project update:
Updated `Api\Api.csproj` to `Microsoft.AspNetCore.Authentication.JwtBearer` `5.0.16` from `5.0.6`

[Microsoft.AspNetCore.Authentication.JwtBearer 5.0.16 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer/5.0.16)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
