### PR TITLE
Automatic update of Microsoft.EntityFrameworkCore to 6.0.4

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore` to `6.0.4` from `6.0.0`
`Microsoft.EntityFrameworkCore 6.0.4` was published at `2022-04-11T23:56:13Z`, 1 day ago

1 project update:
Updated `Api\Api.csproj` to `Microsoft.EntityFrameworkCore` `6.0.4` from `6.0.0`

[Microsoft.EntityFrameworkCore 6.0.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/6.0.4)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
